### PR TITLE
[LaTeX] Several Tests

### DIFF
--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -113,6 +113,28 @@
 %          ^ markup.underline.underline.latex
 
 
+% LIST ENVIRONMENTS
+
+\begin{itemize}
+\item first item
+% <- meta.environment.list.itemize.latex
+\end{itemize}
+
+\begin{enumerate}
+\item first item
+% <- meta.environment.list.enumerate.latex
+\end{enumerate}
+
+\begin{description}
+\item[item] description of item
+% <- meta.environment.list.description.latex
+\end{description}
+
+\begin{list}{(\arabic{listcounter})}{\usecounter{listcounter}}
+\item first item
+% <- meta.environment.list.list.latex
+\end{list}
+
 % VERBATIM
 
 \command{}

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -50,6 +50,49 @@
 %             ^ entity.name.section.latex
 
 
+% REF/LABEL/CITE COMMANDS
+
+\label{sec:name}
+% ^ meta.function.label.latex
+% ^ support.function.label.latex
+
+\ref{sec:name}
+% ^ meta.function.reference.latex
+% ^ support.function.reference.latex
+
+\cite{my:bib:key}
+% ^ meta.function.citation.latex
+% ^ support.function.cite.latex
+
+
+% URL COMMAND
+
+\url{https://www.sublimetext.com/}
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.link.url.latex
+% ^ support.function.url.latex
+%    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.latex
+
+\href{https://www.sublimetext.com/}
+% ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.link.url.latex
+% ^ support.function.url.latex
+%     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.latex
+
+
+% INCLUDE COMMANDS
+
+\include{path/to/file}
+% ^ meta.function.include.latex
+% ^ keyword.control.include.latex
+
+\includeonly{path/to/file.tex}
+% ^ meta.function.include.latex
+% ^ keyword.control.include.latex
+
+\input{path/to/file.tex}
+% ^ meta.function.input.tex
+% ^ keyword.control.input.tex
+
+
 % MARKUP COMMANDS
 
 \emph{text}


### PR DESCRIPTION
Tests for
- ref/cite/label
- url
- input/include
- lists

To think: For description list a special handling for `\item[name]` to emphasize `name` could be nice.

_Important: The command `\ref{...}` is currently not working correctly and disables all syntax highlighting behind the command._
